### PR TITLE
libbt-vendor: Use generated kernel headers

### DIFF
--- a/libbt-vendor/Android.mk
+++ b/libbt-vendor/Android.mk
@@ -46,11 +46,7 @@ LOCAL_C_INCLUDES += \
         $(LOCAL_PATH)/include \
         external/bluetooth/bluedroid/hci/include \
         system/bt/hci/include \
-        $(TARGET_OUT_HEADERS)/bt/hci_qcomm_init \
-        $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
-
-LOCAL_ADDITIONAL_DEPENDENCIES += \
-$(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+        $(TARGET_OUT_HEADERS)/bt/hci_qcomm_init
 
 ifeq ($(BOARD_HAS_QCA_BT_AR3002), true)
 LOCAL_C_FLAGS := \
@@ -66,6 +62,7 @@ LOCAL_SHARED_LIBRARIES := \
         liblog
 
 LOCAL_HEADER_LIBRARIES := \
+        generated_kernel_headers \
         libutils_headers
 
 LOCAL_MODULE := libbt-vendor


### PR DESCRIPTION
Change-Id: Ib334e756e64e0701ce848d4751383317f684b2e3